### PR TITLE
Missing file extension

### DIFF
--- a/install.json
+++ b/install.json
@@ -1,7 +1,7 @@
 {
   "bin": {
     "win32": "start_windows",
-    "linux": "bash start_linux",
+    "linux": "bash start_linux.sh",
     "darwin": "bash start_macos.sh"
   },
   "run": [{


### PR DESCRIPTION
**Summary of changes:**

- Adding the `.sh` extension while calling the `start_linux` script during installation

**Tested:**

- Locally